### PR TITLE
Feat: Customizable styles and css classes

### DIFF
--- a/src/lib/datatable.ts
+++ b/src/lib/datatable.ts
@@ -358,9 +358,9 @@ export const DataTable = defineComponent({
     }
 
     const renderTableHeaderCell = (column: TableColumnInterface) => {
-      const style = { minWidth: /index/i.test(column.path) ? '80px' : '190px' };
+      const style = { minWidth: /index/i.test(column.path) ? '80px' : '190px', ...column.thStyles };
       const onClick = () => handleFilters(filters.pagination, filters.search, column);
-      return h("th", { key: column.label, style, onClick }, [
+      return h("th", { key: column.label, style, class: column.thClasses?.join(" "), onClick }, [
         h("span", column.label),
         column.sortable !== false && renderSortIcon(column),
       ]);
@@ -407,9 +407,10 @@ export const DataTable = defineComponent({
 
 
     const renderDataRowCells = (row: any) => {
-      return tableColumns.value.map((column, key) =>
-        h('td', { key, class: "data-cell" }, renderCellContent(row, column))
-      );
+      return tableColumns.value.map((column, key) => {
+        const classes = ["data-cell", ...column.tdClasses ?? []].join(" ");
+        return h('td', { key, class: classes, style: column.tdStyles }, renderCellContent(row, column))
+      });
     };
 
     const renderCellContent = (row: any, column: TableColumnInterface) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,10 @@ export interface TableColumnInterface {
   drillable?: boolean;
   preSort?: (value: any) => any;
   formatter?: (value: any, row: any) => any;
+  thStyles?: Record<string, string>;
+  thClasses?: Array<string>;
+  tdStyles?: Record<string, string>;
+  tdClasses?: Array<string>;
 }
 
 export interface SortQueryInterface {


### PR DESCRIPTION
Custom styles and css classes can be passed to the the columns to override the default table styles

columns definition now accepts 
- `thStyles` - which a key, value pair of styeles e.g. 
```
{
  minWidth: '10px',
 ... 
// other css styles
}
```

- `thClasses` - which an array of predefined css classes. Note that the classes should not be defined in scoped css modules

- `tdStyles` - same as `thStyles`
- `tdClasses` - same as `thClasses`